### PR TITLE
fix: typo with empty string in model_providers.md

### DIFF
--- a/src/strands_mcp_server/content/model_providers.md
+++ b/src/strands_mcp_server/content/model_providers.md
@@ -97,7 +97,7 @@ agent = Agent(model=litellm_model)
 
 Llama API is a Meta-hosted API service that helps you integrate Llama models into your applications quickly and efficiently.
 
-First install the `` python client:
+First install the `llamaapi` python client:
 ```bash
 pip install strands-agents[llamaapi]
 ```


### PR DESCRIPTION
*Description of changes:*

Fixes small typo where llamaapi should be present inside the ``. This synchronizes with the other providers in the file. The typo should not have impacted MCP integrators as the pip install command is still present. This is largely a visual change if a human was directly looking at the markdown.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
