### PR TITLE
Fix wording in tools content file

### DIFF
--- a/src/strands_mcp_server/content/tools.md
+++ b/src/strands_mcp_server/content/tools.md
@@ -118,7 +118,7 @@ pip install strands-agents-tools
 
 - `image_reader`: Process and analyze images
 - `generate_image`: Create AI generated images with Amazon Bedrock
-- `nova_reels`: Create AI generated images with Nova Reels on Amazon Bedrock
+- `nova_reels`: Create AI generated videos with Nova Reels on Amazon Bedrock
 
 #### AWS Services
 


### PR DESCRIPTION
This PR fixes an inaccuracy in the tools content file, replacing "create AI generated images with Nova Reels" with "create AI generated videos with Nova Reels"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
