### PR TITLE
fix(security): harden _get() against SSRF via redirects and unbounded responses

### DIFF
--- a/src/strands_mcp_server/config.py
+++ b/src/strands_mcp_server/config.py
@@ -9,6 +9,7 @@ class Config:
         llm_texts_url: List of llms.txt URLs to index for documentation
         timeout: HTTP request timeout in seconds
         user_agent: User agent string for HTTP requests
+        max_response_bytes: Maximum HTTP response size in bytes
     """
 
     llm_texts_url: list[str] = field(
@@ -16,6 +17,7 @@ class Config:
     )  # Curated list of llms.txt files to index at startup
     timeout: float = 30.0  # HTTP request timeout in seconds
     user_agent: str = "strands-mcp-docs/1.0"  # User agent for HTTP requests
+    max_response_bytes: int = 2 * 1024 * 1024  # Max HTTP response size (2 MB)
 
 
 # Global configuration instance

--- a/src/strands_mcp_server/utils/doc_fetcher.py
+++ b/src/strands_mcp_server/utils/doc_fetcher.py
@@ -1,9 +1,46 @@
 import html
+import http.client
 import re
+import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 
 from ..config import doc_config
+
+
+def _validate_fetch_url(url: str) -> None:
+    """Reject URLs that fail protocol-level safety checks."""
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https":
+        raise urllib.error.URLError("only https URLs are allowed")
+    if "@" in (parsed.netloc or ""):
+        raise urllib.error.URLError("URLs with userinfo (@) are not allowed")
+    if not parsed.hostname:
+        raise urllib.error.URLError("URL has no hostname")
+
+
+class _SameHostRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Allow redirects only within the same scheme+host. Block cross-host redirects to prevent SSRF."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: http.client.HTTPResponse,
+        code: int,
+        msg: str,
+        headers: http.client.HTTPMessage,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        _validate_fetch_url(newurl)
+        original = urllib.parse.urlparse(req.full_url)
+        target = urllib.parse.urlparse(newurl)
+        if target.hostname != original.hostname:
+            raise urllib.error.URLError(f"cross-host redirect blocked ({code})")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+_opener = urllib.request.build_opener(_SameHostRedirectHandler)
 
 # Example: "[Quickstart](https://strandsagents.com/.../index.md)"
 _MD_LINK = re.compile(r"\[([^\]]+)\]\((https?://[^\)]+)\)")
@@ -39,11 +76,16 @@ def _get(url: str) -> str:
         The decoded text content of the response
 
     Raises:
-        urllib.error.URLError: If the request fails
+        urllib.error.URLError: If the URL fails validation, the request fails, or a cross-host redirect is attempted
+        RuntimeError: If the response exceeds max_response_bytes
     """
+    _validate_fetch_url(url)
     req = urllib.request.Request(url, headers={"User-Agent": doc_config.user_agent})
-    with urllib.request.urlopen(req, timeout=doc_config.timeout) as r:
-        return r.read().decode("utf-8", errors="ignore")
+    with _opener.open(req, timeout=doc_config.timeout) as r:
+        data = r.read(doc_config.max_response_bytes + 1)
+        if len(data) > doc_config.max_response_bytes:
+            raise RuntimeError(f"response exceeds {doc_config.max_response_bytes} bytes")
+        return data.decode("utf-8", errors="ignore")
 
 
 def parse_llms_txt(url: str) -> list[tuple[str, str]]:

--- a/tests/test_doc_fetcher.py
+++ b/tests/test_doc_fetcher.py
@@ -1,0 +1,141 @@
+"""Tests for doc_fetcher security hardening: redirect policy and response size cap."""
+
+import urllib.error
+import urllib.request
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands_mcp_server.config import doc_config
+from strands_mcp_server.utils.doc_fetcher import _get, _SameHostRedirectHandler, _validate_fetch_url
+
+
+@pytest.fixture
+def mock_http_response():
+    """Create a mock HTTP response usable as a context manager."""
+    response = MagicMock()
+    response.__enter__ = lambda s: s
+    response.__exit__ = MagicMock(return_value=False)
+    return response
+
+
+class TestSameHostRedirectHandler:
+    """Verify that only same-host HTTPS redirects are allowed."""
+
+    def _make_request(self, url: str) -> urllib.request.Request:
+        return urllib.request.Request(url)
+
+    def test_same_host_redirect_allowed(self):
+        handler = _SameHostRedirectHandler()
+        req = self._make_request("https://strandsagents.com/old-page/")
+
+        result = handler.redirect_request(
+            req=req,
+            fp=MagicMock(),
+            code=301,
+            msg="Moved",
+            headers=MagicMock(),
+            newurl="https://strandsagents.com/new-page/",
+        )
+
+        assert isinstance(result, urllib.request.Request)
+        assert result.full_url == "https://strandsagents.com/new-page/"
+
+    def test_scheme_downgrade_blocked(self):
+        handler = _SameHostRedirectHandler()
+        req = self._make_request("https://strandsagents.com/page/")
+
+        with pytest.raises(urllib.error.URLError, match="only https URLs are allowed"):
+            handler.redirect_request(
+                req=req,
+                fp=MagicMock(),
+                code=302,
+                msg="Found",
+                headers=MagicMock(),
+                newurl="http://strandsagents.com/page/",
+            )
+
+    def test_redirect_with_different_https_host_blocked(self):
+        handler = _SameHostRedirectHandler()
+        req = self._make_request("https://strandsagents.com/page/")
+
+        with pytest.raises(urllib.error.URLError, match="cross-host redirect blocked"):
+            handler.redirect_request(
+                req=req,
+                fp=MagicMock(),
+                code=302,
+                msg="Found",
+                headers=MagicMock(),
+                newurl="https://evil.com/steal/",
+            )
+
+
+class TestResponseSizeCap:
+    """Verify that oversized responses are rejected."""
+
+    @patch("strands_mcp_server.utils.doc_fetcher._opener")
+    def test_oversized_response_raises_runtime_error(self, mock_opener, mock_http_response):
+        oversize_data = b"x" * (doc_config.max_response_bytes + 1)
+        mock_http_response.read.return_value = oversize_data
+        mock_http_response.headers = {}
+        mock_opener.open.return_value = mock_http_response
+
+        with pytest.raises(RuntimeError, match="response exceeds"):
+            _get("https://strandsagents.com/latest/")
+
+        mock_http_response.read.assert_called_once_with(doc_config.max_response_bytes + 1)
+
+    @patch("strands_mcp_server.utils.doc_fetcher._opener")
+    def test_boundary_response_at_exact_limit_succeeds(self, mock_opener, mock_http_response):
+        boundary_data = b"x" * doc_config.max_response_bytes
+        mock_http_response.read.return_value = boundary_data
+        mock_http_response.headers = {}
+        mock_opener.open.return_value = mock_http_response
+
+        result = _get("https://strandsagents.com/latest/")
+
+        assert result == boundary_data.decode("utf-8")
+        mock_http_response.read.assert_called_once_with(doc_config.max_response_bytes + 1)
+
+    @patch("strands_mcp_server.utils.doc_fetcher._opener")
+    def test_normal_response_returns_content(self, mock_opener, mock_http_response):
+        body = b"<html><body>Hello</body></html>"
+        mock_http_response.read.return_value = body
+        mock_http_response.headers = {}
+        mock_opener.open.return_value = mock_http_response
+
+        result = _get("https://strandsagents.com/latest/")
+
+        assert result == body.decode("utf-8")
+        mock_http_response.read.assert_called_once_with(doc_config.max_response_bytes + 1)
+
+
+class TestUrlValidation:
+    """Verify that _get() rejects unsafe URLs before making any request."""
+
+    @pytest.mark.parametrize("url", ["http://example.com/", "ftp://example.com/", "file:///etc/passwd"])
+    def test_non_https_url_rejected(self, url):
+        with pytest.raises(urllib.error.URLError, match="only https URLs are allowed"):
+            _validate_fetch_url(url)
+
+    def test_userinfo_url_rejected(self):
+        with pytest.raises(urllib.error.URLError, match="userinfo"):
+            _validate_fetch_url("https://user@evil.com/path")
+
+    def test_no_hostname_url_rejected(self):
+        with pytest.raises(urllib.error.URLError, match="no hostname"):
+            _validate_fetch_url("https:///path")
+
+    def test_get_rejects_non_https(self):
+        with pytest.raises(urllib.error.URLError, match="only https URLs are allowed"):
+            _get("http://example.com/")
+
+    @patch("strands_mcp_server.utils.doc_fetcher._opener")
+    def test_https_url_passes_validation(self, mock_opener, mock_http_response):
+        mock_http_response.read.return_value = b"ok"
+        mock_http_response.headers = {}
+        mock_opener.open.return_value = mock_http_response
+
+        result = _get("https://strandsagents.com/page/")
+
+        assert result == "ok"


### PR DESCRIPTION
## Summary

`_get()` follows redirects without restriction and reads responses without a size limit. A malicious or compromised URL in an `llms.txt` file could exploit this to redirect requests to unintended hosts or stream unbounded data into memory.

This PR hardens `_get()` with three measures:

- **URL validation on redirect targets** — Redirect destinations are validated with the same checks as initial requests (HTTPS-only, no userinfo, hostname required)
- **Same-host redirect policy** — Cross-host redirects are blocked; only redirects within the original hostname are followed
- **Response size cap** — `read()` is bounded to `max_response_bytes + 1` (default 2 MB), preventing memory exhaustion from oversized responses

All changes use stdlib only. No new dependencies.

## Changes

- `config.py` — Add `max_response_bytes` field (default 2 MB)
- `doc_fetcher.py` — Add `_validate_fetch_url()`, `_SameHostRedirectHandler`, bounded read in `_get()`
- `test_doc_fetcher.py` — 13 unit tests covering redirect policy, size cap, and URL validation

## Test plan

- [x] `pytest tests/test_doc_fetcher.py` — 13/13 passing
- [x] `pytest tests_integ/` — 9/9 integration tests passing against live strandsagents.com
- [x] Manual MCP server test via live Claude subprocess — 6/6 passing

### Manual test protocol

| # | Test | Method | Result |
|---|------|--------|--------|
| 1 | `search_docs(query="how to create an agent", k=3)` | Returns 3 ranked results with url, title, score, snippet | PASS |
| 2 | `fetch_doc(uri=<url from test 1>)` - TOC mode | Small doc returns full content; large doc returns sections | PASS |
| 3 | `fetch_doc(uri=<large doc>, section="1")` - Section mode | Returns section_id, section_title, content | PASS |
| 4 | `fetch_doc(uri="")` - Empty URI | Returns catalog of 407 URLs with url and title fields | PASS |
| 5 | `fetch_doc(uri="http://169.254.169.254/latest/meta-data/")` - SSRF | Rejected: "only https://strandsagents.com URLs allowed" | PASS |
| 6 | `fetch_doc(uri="https://strandsagents.com/docs/user-guide/concepts/agents/hooks/index.md")` - Legitimate fetch | Returns TOC with 9 sections | PASS |