### PR TITLE
fix(mcp): index document content on hydration and score with BM25

### DIFF
--- a/strands-mcp/README.md
+++ b/strands-mcp/README.md
@@ -37,12 +37,13 @@ This MCP server provides curated documentation access to your GenAI tools via ll
 
 ## Features
 
-- **Smart Document Search**: TF-IDF based search with Markdown-aware scoring that prioritizes titles, headers, and code blocks
+- **Smart Document Search**: BM25-based search with Markdown-aware scoring that prioritizes titles, headers, and code blocks
 - **Section-Based Browsing**: Browse document structure via table of contents, then fetch only the section you need - more token-efficient than retrieving full pages
 - **Curated Content**: Indexes documentation from llms.txt files with clean, human-readable titles
-- **On-Demand Fetching**: Lazy-loads full document content only when needed for optimal performance
+- **On-Demand Fetching**: Lazy-loads full document content only when needed for optimal performance. Documents are indexed on first access (hydration), making body-only terms searchable after the initial fetch.
 - **Snippet Generation**: Provides contextual snippets with relevance scoring for quick overview
 - **Real URL Support**: Works with actual HTTPS URLs while maintaining backward compatibility
+- **Optional Background Prefetch**: Set `STRANDS_MCP_PREFETCH_ALL=1` to prefetch all pages at startup. This enables immediate full-text search but uses eventual consistency semantics (search results may be transiently stale during hydration).
 
 ## Prerequisites
 

--- a/strands-mcp/src/strands_mcp_server/server.py
+++ b/strands-mcp/src/strands_mcp_server/server.py
@@ -61,13 +61,20 @@ def search_docs(query: str, k: int = 5) -> List[Dict[str, Any]]:
     results = index.search(query, k=k) if index else []
     url_cache = cache.get_url_cache()
 
-    # Collect top-k URLs that need hydration (no content yet)
-    # Simplified: Direct hydration in one pass
+    # Hydrate top-k results that don't have content yet
+    # Track whether hydration changed the index (content was updated)
+    any_hydrated = False
     top = results[: min(len(results), cache.SNIPPET_HYDRATE_MAX)]
     for _, doc in top:
         cached = url_cache.get(doc.uri)
         if cached is None or not cached.content:
             cache.ensure_page(doc.uri)
+            any_hydrated = True
+
+    # Re-rank if hydration changed the index, so scores are consistent with content
+    # This ensures the first search response reflects ONE consistent index state
+    if any_hydrated and index:
+        results = index.search(query, k=k)
 
     # Build response with real content snippets when available
     return_docs: List[Dict[str, Any]] = []

--- a/strands-mcp/src/strands_mcp_server/utils/cache.py
+++ b/strands-mcp/src/strands_mcp_server/utils/cache.py
@@ -1,3 +1,5 @@
+import os
+import threading
 from typing import Dict
 
 from ..config import doc_config
@@ -8,8 +10,53 @@ _INDEX: indexer.IndexSearch | None = None
 _URL_CACHE: Dict[str, doc_fetcher.Page | None] = {}  # url -> Page (None if not fetched yet)
 _URL_TITLES: Dict[str, str] = {}  # url -> curated title from llms.txt
 _LINKS_LOADED = False
+_PREFETCH_STARTED = False
 
 SNIPPET_HYDRATE_MAX = 5  # how many top results to hydrate with content
+
+# Environment variable to enable background prefetch (default: OFF)
+PREFETCH_ENV_VAR = "STRANDS_MCP_PREFETCH_ALL"
+
+
+def _is_prefetch_enabled() -> bool:
+    """Check if background prefetch is enabled via environment variable.
+
+    Returns:
+        True if STRANDS_MCP_PREFETCH_ALL is set to a truthy value (1, true, yes)
+    """
+    val = os.environ.get(PREFETCH_ENV_VAR, "").lower()
+    return val in ("1", "true", "yes")
+
+
+def _background_prefetch() -> None:
+    """Background thread function to prefetch all pages.
+
+    Iterates through all URLs in the cache and fetches content for any
+    that haven't been fetched yet. Updates the index with hydrated content.
+    Note: Search may return transiently stale results during hydration (eventual consistency).
+    """
+    global _URL_CACHE, _INDEX
+    for url in list(_URL_CACHE.keys()):
+        if _URL_CACHE.get(url) is None:
+            try:
+                ensure_page(url)
+            except Exception:
+                pass  # Silently skip failures in background prefetch
+
+
+def _start_background_prefetch() -> None:
+    """Start background prefetch thread if enabled and not already started.
+
+    This function is idempotent - calling it multiple times has no effect
+    after the first successful start.
+    """
+    global _PREFETCH_STARTED
+    if _PREFETCH_STARTED or not _is_prefetch_enabled():
+        return
+
+    _PREFETCH_STARTED = True
+    thread = threading.Thread(target=_background_prefetch, daemon=True)
+    thread.start()
 
 
 def load_links_only() -> None:
@@ -19,11 +66,15 @@ def load_links_only() -> None:
     configured llms.txt files. Content is not fetched during initialization for
     faster startup times.
 
+    If STRANDS_MCP_PREFETCH_ALL environment variable is set to a truthy value,
+    background prefetch of all pages will be started after initialization.
+
     Side Effects:
         - Updates global _INDEX with document entries
         - Populates _URL_TITLES with curated titles
         - Sets placeholder entries in _URL_CACHE
         - Sets _LINKS_LOADED to True
+        - May start background prefetch thread if enabled
     """
     global _INDEX, _LINKS_LOADED, _URL_TITLES, _URL_CACHE
     if _INDEX is None:
@@ -44,6 +95,9 @@ def load_links_only() -> None:
 
     _LINKS_LOADED = True
 
+    # Start background prefetch if enabled
+    _start_background_prefetch()
+
 
 def ensure_ready() -> None:
     """Ensure the search index is initialized and ready for use.
@@ -57,6 +111,10 @@ def ensure_ready() -> None:
 
 def ensure_page(url: str) -> doc_fetcher.Page | None:
     """Ensure a page is cached, fetching it if necessary.
+
+    When a page is fetched, also updates the search index with the hydrated content
+    so that body-only terms become searchable. This operation is idempotent -
+    re-fetching an already-cached page has no effect.
 
     Args:
         url: The URL of the page to ensure is cached
@@ -73,6 +131,11 @@ def ensure_page(url: str) -> doc_fetcher.Page | None:
         display_title = text_processor.format_display_title(url, raw.title, _URL_TITLES)
         page = doc_fetcher.Page(url=url, title=display_title, content=raw.content)
         _URL_CACHE[url] = page
+
+        # Update the search index with the hydrated content
+        if _INDEX is not None:
+            _INDEX.update_content(url, raw.content)
+
         return page
     except Exception:
         return None

--- a/strands-mcp/src/strands_mcp_server/utils/cache.py
+++ b/strands-mcp/src/strands_mcp_server/utils/cache.py
@@ -116,6 +116,11 @@ def ensure_page(url: str) -> doc_fetcher.Page | None:
     so that body-only terms become searchable. This operation is idempotent -
     re-fetching an already-cached page has no effect.
 
+    Thread Safety:
+        If indexing fails after fetch succeeds, the page is NOT cached, allowing
+        retry on subsequent calls. This ensures body terms eventually become
+        searchable even after transient indexing failures.
+
     Args:
         url: The URL of the page to ensure is cached
 
@@ -130,11 +135,14 @@ def ensure_page(url: str) -> doc_fetcher.Page | None:
         raw = doc_fetcher.fetch_and_clean(url)
         display_title = text_processor.format_display_title(url, raw.title, _URL_TITLES)
         page = doc_fetcher.Page(url=url, title=display_title, content=raw.content)
-        _URL_CACHE[url] = page
 
-        # Update the search index with the hydrated content
+        # Update the search index with the hydrated content BEFORE caching
+        # If this fails, we leave the page un-cached so retry is possible
         if _INDEX is not None:
             _INDEX.update_content(url, raw.content)
+
+        # Only cache after indexing succeeds
+        _URL_CACHE[url] = page
 
         return page
     except Exception:

--- a/strands-mcp/src/strands_mcp_server/utils/indexer.py
+++ b/strands-mcp/src/strands_mcp_server/utils/indexer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import re
+import threading
 from dataclasses import dataclass
 from typing import Dict, List, Set, Tuple
 
@@ -56,10 +57,17 @@ class IndexSearch:
 
     Provides document indexing and search optimized for technical documentation.
     Uses BM25 scoring with special handling for Markdown structure elements.
+
+    Thread Safety:
+        All public methods (add, update_content, search) are thread-safe.
+        A single lock guards all shared state mutations to ensure atomic
+        read-modify-write operations when used by concurrent threads
+        (e.g., background prefetch daemon + foreground ensure_page).
     """
 
     def __init__(self) -> None:
         """Initialize an empty search index."""
+        self._lock = threading.Lock()
         self.docs: List[Doc] = []
         self.doc_frequency: Dict[str, int] = {}
         self.doc_indices: Dict[str, List[int]] = {}  # token -> doc indices
@@ -106,75 +114,82 @@ class IndexSearch:
         return seen
 
     def add(self, doc: Doc) -> None:
-        """Add a document to the search index."""
-        idx = len(self.docs)
-        self.docs.append(doc)
-        self.uri_to_idx[doc.uri] = idx
+        """Add a document to the search index.
 
-        # Cache document length for BM25
-        doc_len = _count_doc_tokens(doc)
-        self._doc_lengths[idx] = doc_len
-        self._total_doc_length += doc_len
+        Thread-safe: acquires lock for the entire add operation.
+        """
+        with self._lock:
+            idx = len(self.docs)
+            self.docs.append(doc)
+            self.uri_to_idx[doc.uri] = idx
 
-        # Index tokens and track which tokens belong to this doc
-        self.doc_tokens[idx] = self._index_tokens_for_doc(idx, doc)
+            # Cache document length for BM25
+            doc_len = _count_doc_tokens(doc)
+            self._doc_lengths[idx] = doc_len
+            self._total_doc_length += doc_len
+
+            # Index tokens and track which tokens belong to this doc
+            self.doc_tokens[idx] = self._index_tokens_for_doc(idx, doc)
 
     def update_content(self, uri: str, new_content: str) -> bool:
         """Update content for an existing document and reindex.
 
         Called when document content is hydrated after initial title-only indexing.
         Idempotent - calling with the same content multiple times is safe.
+
+        Thread-safe: acquires lock for the entire update operation.
         """
-        idx = self.uri_to_idx.get(uri)
-        if idx is None:
-            return False
+        with self._lock:
+            idx = self.uri_to_idx.get(uri)
+            if idx is None:
+                return False
 
-        doc = self.docs[idx]
+            doc = self.docs[idx]
 
-        # Skip if content unchanged (idempotent)
-        if doc.content == new_content:
+            # Skip if content unchanged (idempotent)
+            if doc.content == new_content:
+                return True
+
+            # Update cached length and avgdl
+            old_length = self._doc_lengths.get(idx, 0)
+            doc.content = new_content
+            new_length = _count_doc_tokens(doc)
+            self._doc_lengths[idx] = new_length
+            self._total_doc_length = self._total_doc_length - old_length + new_length
+
+            # Get old tokens and new tokens
+            old_tokens = self.doc_tokens.get(idx, set())
+            new_tokens = self._extract_tokens(doc)
+
+            # Tokens to remove from index (in old but not in new)
+            tokens_to_remove = old_tokens - new_tokens
+
+            # Tokens to add to index (in new but not in old)
+            tokens_to_add = new_tokens - old_tokens
+
+            # Update document frequency for removed tokens
+            for tok in tokens_to_remove:
+                if tok in self.doc_frequency:
+                    self.doc_frequency[tok] -= 1
+                    if self.doc_frequency[tok] <= 0:
+                        del self.doc_frequency[tok]
+                if tok in self.doc_indices:
+                    try:
+                        self.doc_indices[tok].remove(idx)
+                    except ValueError:
+                        pass
+                    if not self.doc_indices[tok]:
+                        del self.doc_indices[tok]
+
+            # Add new tokens to index
+            for tok in tokens_to_add:
+                self.doc_indices.setdefault(tok, []).append(idx)
+                self.doc_frequency[tok] = self.doc_frequency.get(tok, 0) + 1
+
+            # Update tracked tokens
+            self.doc_tokens[idx] = new_tokens
+
             return True
-
-        # Update cached length and avgdl
-        old_length = self._doc_lengths.get(idx, 0)
-        doc.content = new_content
-        new_length = _count_doc_tokens(doc)
-        self._doc_lengths[idx] = new_length
-        self._total_doc_length = self._total_doc_length - old_length + new_length
-
-        # Get old tokens and new tokens
-        old_tokens = self.doc_tokens.get(idx, set())
-        new_tokens = self._extract_tokens(doc)
-
-        # Tokens to remove from index (in old but not in new)
-        tokens_to_remove = old_tokens - new_tokens
-
-        # Tokens to add to index (in new but not in old)
-        tokens_to_add = new_tokens - old_tokens
-
-        # Update document frequency for removed tokens
-        for tok in tokens_to_remove:
-            if tok in self.doc_frequency:
-                self.doc_frequency[tok] -= 1
-                if self.doc_frequency[tok] <= 0:
-                    del self.doc_frequency[tok]
-            if tok in self.doc_indices:
-                try:
-                    self.doc_indices[tok].remove(idx)
-                except ValueError:
-                    pass
-                if not self.doc_indices[tok]:
-                    del self.doc_indices[tok]
-
-        # Add new tokens to index
-        for tok in tokens_to_add:
-            self.doc_indices.setdefault(tok, []).append(idx)
-            self.doc_frequency[tok] = self.doc_frequency.get(tok, 0) + 1
-
-        # Update tracked tokens
-        self.doc_tokens[idx] = new_tokens
-
-        return True
 
     def _extract_tokens(self, doc: Doc) -> Set[str]:
         """Extract unique tokens from a document without indexing."""
@@ -208,6 +223,8 @@ class IndexSearch:
 
         Uses BM25 scoring with Markdown-aware enhancements for headers (4x),
         code (2x), and links (2x). Title matches receive adaptive boosting.
+
+        Thread-safe: acquires lock to ensure consistent reads of index state.
         """
 
         def _title_boost_for(doc: Doc) -> int:
@@ -248,7 +265,7 @@ class IndexSearch:
                 return 0.0
 
             # Use cached document length
-            doc_len = self._doc_lengths.get(idx, 1)
+            doc_len = doc_lengths.get(idx, 1)
             if doc_len == 0:
                 doc_len = 1
 
@@ -259,18 +276,28 @@ class IndexSearch:
             return idf * (numerator / denominator)
 
         q_tokens = [t.lower() for t in _TOKEN.findall(query)]
+
+        # Snapshot index state under lock for consistent reads
+        with self._lock:
+            docs_snapshot = list(self.docs)
+            doc_frequency_snapshot = dict(self.doc_frequency)
+            doc_indices_snapshot = {k: list(v) for k, v in self.doc_indices.items()}
+            doc_lengths = dict(self._doc_lengths)
+            total_doc_length = self._total_doc_length
+
         scores: Dict[int, float] = {}
-        N = max(len(self.docs), 1)
-        avgdl = self._get_avgdl()
+        N = max(len(docs_snapshot), 1)
+        avgdl = total_doc_length / N if N > 0 else 1.0
 
         for qt in q_tokens:
-            n = self.doc_frequency.get(qt, 0)
+            n = doc_frequency_snapshot.get(qt, 0)
             idf = math.log((N - n + 0.5) / (n + 0.5) + 1)
 
-            for idx in self.doc_indices.get(qt, []):
-                d = self.docs[idx]
-                score = _bm25_score(idx, d, qt, idf, avgdl)
-                scores[idx] = scores.get(idx, 0.0) + score
+            for idx in doc_indices_snapshot.get(qt, []):
+                if idx < len(docs_snapshot):
+                    d = docs_snapshot[idx]
+                    score = _bm25_score(idx, d, qt, idf, avgdl)
+                    scores[idx] = scores.get(idx, 0.0) + score
 
-        ranked = sorted(((score, self.docs[i]) for i, score in scores.items()), key=lambda x: x[0], reverse=True)
+        ranked = sorted(((score, docs_snapshot[i]) for i, score in scores.items()), key=lambda x: x[0], reverse=True)
         return ranked[:k]

--- a/strands-mcp/src/strands_mcp_server/utils/indexer.py
+++ b/strands-mcp/src/strands_mcp_server/utils/indexer.py
@@ -64,6 +64,11 @@ class IndexSearch:
     Provides document indexing and search optimized for technical documentation.
     Uses BM25 scoring with special handling for Markdown structure elements.
 
+    Note:
+        This class is an internal implementation detail of strands-mcp-server.
+        It is NOT part of the public API and may change without notice.
+        Do not import or depend on it from external code.
+
     Thread Safety:
         All public methods (add, update_content, search) are thread-safe.
         A single lock guards all shared state mutations to ensure atomic

--- a/strands-mcp/src/strands_mcp_server/utils/indexer.py
+++ b/strands-mcp/src/strands_mcp_server/utils/indexer.py
@@ -41,6 +41,12 @@ _SHORT_PAGE_THRESHOLD = 800  # character threshold for short pages
 _BM25_K1 = 1.5  # term frequency saturation parameter
 _BM25_B = 0.75  # document length normalization parameter
 
+# Test-only hook: if set to a callable, called mid-transaction in add()/update_content()
+# after reading shared state but before writing it back. Used by concurrency tests
+# to force deterministic interleaving that exposes races hidden by the GIL.
+# Production: always None (zero overhead - guarded by `if _TEST_YIELD is not None`).
+_TEST_YIELD: object = None
+
 
 def _tokenize(text: str) -> List[str]:
     """Tokenize text into lowercase tokens."""
@@ -108,7 +114,12 @@ class IndexSearch:
             tok_lower = tok.lower()
             if tok_lower not in seen:
                 self.doc_indices.setdefault(tok_lower, []).append(idx)
-                self.doc_frequency[tok_lower] = self.doc_frequency.get(tok_lower, 0) + 1
+                # Read-modify-write on doc_frequency: the vulnerable seam.
+                # Test hook called between read and write to force interleaving.
+                current_df = self.doc_frequency.get(tok_lower, 0)
+                if _TEST_YIELD is not None:
+                    _TEST_YIELD()  # type: ignore[operator]
+                self.doc_frequency[tok_lower] = current_df + 1
                 seen.add(tok_lower)
 
         return seen
@@ -184,7 +195,11 @@ class IndexSearch:
             # Add new tokens to index
             for tok in tokens_to_add:
                 self.doc_indices.setdefault(tok, []).append(idx)
-                self.doc_frequency[tok] = self.doc_frequency.get(tok, 0) + 1
+                # Read-modify-write on doc_frequency: the vulnerable seam.
+                current_df = self.doc_frequency.get(tok, 0)
+                if _TEST_YIELD is not None:
+                    _TEST_YIELD()  # type: ignore[operator]
+                self.doc_frequency[tok] = current_df + 1
 
             # Update tracked tokens
             self.doc_tokens[idx] = new_tokens

--- a/strands-mcp/src/strands_mcp_server/utils/indexer.py
+++ b/strands-mcp/src/strands_mcp_server/utils/indexer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import re
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict, List, Set, Tuple
 
 # Enhanced tokenization patterns
 _TOKEN = re.compile(r"[A-Za-z0-9_]+")
@@ -24,10 +24,10 @@ class Doc:
         index_title: Searchable title text including variants and synonyms
     """
 
-    uri: str  # Unique identifier/URL for the document
-    display_title: str  # Human-readable title shown to users
-    content: str  # Full text content (may be empty before fetching)
-    index_title: str  # Searchable title text including variants
+    uri: str
+    display_title: str
+    content: str
+    index_title: str
 
 
 # Title boost constants
@@ -36,67 +36,57 @@ _TITLE_BOOST_SHORT = 5  # boost for short pages (<800 chars)
 _TITLE_BOOST_LONG = 3  # boost for longer pages
 _SHORT_PAGE_THRESHOLD = 800  # character threshold for short pages
 
+# BM25 parameters
+_BM25_K1 = 1.5  # term frequency saturation parameter
+_BM25_B = 0.75  # document length normalization parameter
+
+
+def _tokenize(text: str) -> List[str]:
+    """Tokenize text into lowercase tokens."""
+    return [t.lower() for t in _TOKEN.findall(text)]
+
+
+def _count_doc_tokens(doc: Doc) -> int:
+    """Count total tokens in a document for length normalization."""
+    return len(_tokenize(doc.index_title)) + len(_tokenize(doc.content))
+
 
 class IndexSearch:
-    """Lightweight inverted index with TF-IDF scoring and Markdown awareness.
+    """Lightweight inverted index with BM25 scoring and Markdown awareness.
 
-    This class provides document indexing and search functionality optimized for
-    technical documentation. It uses TF-IDF scoring with special handling for
-    Markdown structure elements like headers, code blocks, and links.
-
-    Features:
-        - Indexes searchable titles (not display titles) for synonym support
-        - Adaptive title boosting based on content length
-        - Enhanced scoring for Markdown elements (headers, code, links)
-        - Lightweight implementation without external dependencies
-
-    Attributes:
-        docs: List of indexed documents
-        doc_frequency: Token document frequency for IDF calculation
-        doc_indices: Inverted index mapping tokens to document indices
+    Provides document indexing and search optimized for technical documentation.
+    Uses BM25 scoring with special handling for Markdown structure elements.
     """
 
     def __init__(self) -> None:
         """Initialize an empty search index."""
         self.docs: List[Doc] = []
-        self.doc_frequency: Dict[str, int] = {}  # document frequency
+        self.doc_frequency: Dict[str, int] = {}
         self.doc_indices: Dict[str, List[int]] = {}  # token -> doc indices
+        self.uri_to_idx: Dict[str, int] = {}  # uri -> doc index for updates
+        self.doc_tokens: Dict[int, Set[str]] = {}  # idx -> set of tokens (for rehydration)
+        self._doc_lengths: Dict[int, int] = {}  # idx -> cached token count for BM25
+        self._total_doc_length: int = 0  # sum of all document lengths for avgdl
 
-    def add(self, doc: Doc) -> None:
-        """Add a document to the search index.
+    def _get_avgdl(self) -> float:
+        """Get average document length for BM25."""
+        if not self.docs:
+            return 1.0
+        return self._total_doc_length / len(self.docs)
 
-        Args:
-            doc: Document to add to the index
+    def _index_tokens_for_doc(self, idx: int, doc: Doc) -> Set[str]:
+        """Extract and index tokens from a document."""
+        seen: Set[str] = set()
 
-        Note:
-            Extracts and weights different content types:
-            - Titles: Highest weight for search relevance
-            - Headers: High weight for structural importance
-            - Code blocks: Medium weight for technical content
-            - Link text: Medium weight for navigation context
-            - Body text: Base weight for general content
-        """
-        idx = len(self.docs)
-        self.docs.append(doc)
-        seen: set[str] = set()
-
-        # Extract MD-specific content with different weights
         content = doc.content.lower()
         title_text = doc.index_title.lower()
-
-        # Extract headers (high importance)
         headers = " ".join(_MD_HEADER.findall(doc.content))
-
-        # Extract code content (medium importance for tech docs)
         code_blocks = " ".join(_MD_CODE_BLOCK.findall(doc.content))
         inline_code = " ".join(_MD_INLINE_CODE.findall(doc.content))
-
-        # Extract link text (medium importance)
         link_text = " ".join(_MD_LINK_TEXT.findall(doc.content))
 
-        # Build weighted haystack: title gets highest weight
         haystack_parts = [
-            title_text,  # Will get title boost in search
+            title_text,
             headers.lower(),
             link_text.lower(),
             code_blocks.lower(),
@@ -107,99 +97,180 @@ class IndexSearch:
         haystack = " ".join(part for part in haystack_parts if part)
 
         for tok in _TOKEN.findall(haystack):
+            tok_lower = tok.lower()
+            if tok_lower not in seen:
+                self.doc_indices.setdefault(tok_lower, []).append(idx)
+                self.doc_frequency[tok_lower] = self.doc_frequency.get(tok_lower, 0) + 1
+                seen.add(tok_lower)
+
+        return seen
+
+    def add(self, doc: Doc) -> None:
+        """Add a document to the search index."""
+        idx = len(self.docs)
+        self.docs.append(doc)
+        self.uri_to_idx[doc.uri] = idx
+
+        # Cache document length for BM25
+        doc_len = _count_doc_tokens(doc)
+        self._doc_lengths[idx] = doc_len
+        self._total_doc_length += doc_len
+
+        # Index tokens and track which tokens belong to this doc
+        self.doc_tokens[idx] = self._index_tokens_for_doc(idx, doc)
+
+    def update_content(self, uri: str, new_content: str) -> bool:
+        """Update content for an existing document and reindex.
+
+        Called when document content is hydrated after initial title-only indexing.
+        Idempotent - calling with the same content multiple times is safe.
+        """
+        idx = self.uri_to_idx.get(uri)
+        if idx is None:
+            return False
+
+        doc = self.docs[idx]
+
+        # Skip if content unchanged (idempotent)
+        if doc.content == new_content:
+            return True
+
+        # Update cached length and avgdl
+        old_length = self._doc_lengths.get(idx, 0)
+        doc.content = new_content
+        new_length = _count_doc_tokens(doc)
+        self._doc_lengths[idx] = new_length
+        self._total_doc_length = self._total_doc_length - old_length + new_length
+
+        # Get old tokens and new tokens
+        old_tokens = self.doc_tokens.get(idx, set())
+        new_tokens = self._extract_tokens(doc)
+
+        # Tokens to remove from index (in old but not in new)
+        tokens_to_remove = old_tokens - new_tokens
+
+        # Tokens to add to index (in new but not in old)
+        tokens_to_add = new_tokens - old_tokens
+
+        # Update document frequency for removed tokens
+        for tok in tokens_to_remove:
+            if tok in self.doc_frequency:
+                self.doc_frequency[tok] -= 1
+                if self.doc_frequency[tok] <= 0:
+                    del self.doc_frequency[tok]
+            if tok in self.doc_indices:
+                try:
+                    self.doc_indices[tok].remove(idx)
+                except ValueError:
+                    pass
+                if not self.doc_indices[tok]:
+                    del self.doc_indices[tok]
+
+        # Add new tokens to index
+        for tok in tokens_to_add:
             self.doc_indices.setdefault(tok, []).append(idx)
-            if tok not in seen:
-                self.doc_frequency[tok] = self.doc_frequency.get(tok, 0) + 1
-                seen.add(tok)
+            self.doc_frequency[tok] = self.doc_frequency.get(tok, 0) + 1
+
+        # Update tracked tokens
+        self.doc_tokens[idx] = new_tokens
+
+        return True
+
+    def _extract_tokens(self, doc: Doc) -> Set[str]:
+        """Extract unique tokens from a document without indexing."""
+        seen: Set[str] = set()
+
+        content = doc.content.lower()
+        title_text = doc.index_title.lower()
+        headers = " ".join(_MD_HEADER.findall(doc.content))
+        code_blocks = " ".join(_MD_CODE_BLOCK.findall(doc.content))
+        inline_code = " ".join(_MD_INLINE_CODE.findall(doc.content))
+        link_text = " ".join(_MD_LINK_TEXT.findall(doc.content))
+
+        haystack_parts = [
+            title_text,
+            headers.lower(),
+            link_text.lower(),
+            code_blocks.lower(),
+            inline_code.lower(),
+            content,
+        ]
+
+        haystack = " ".join(part for part in haystack_parts if part)
+
+        for tok in _TOKEN.findall(haystack):
+            seen.add(tok.lower())
+
+        return seen
 
     def search(self, query: str, k: int = 8) -> List[Tuple[float, Doc]]:
         """Search the index and return ranked results.
 
-        Args:
-            query: Search query string
-            k: Maximum number of results to return
-
-        Returns:
-            List of (score, document) tuples sorted by relevance (highest first)
-
-        Note:
-            Uses TF-IDF scoring with Markdown-aware enhancements:
-            - Title matches receive adaptive boosting
-            - Header matches get 4x weight
-            - Code and link matches get 2x weight
-            - Empty content gets higher title boost for better ranking
+        Uses BM25 scoring with Markdown-aware enhancements for headers (4x),
+        code (2x), and links (2x). Title matches receive adaptive boosting.
         """
 
         def _title_boost_for(doc: Doc) -> int:
-            """Calculate title boost factor based on document content length.
-
-            Args:
-                doc: Document to calculate boost for
-
-            Returns:
-                Boost multiplier for title matches
-            """
+            """Calculate title boost based on content length."""
             n = len(doc.content)
-            if n == 0:  # not fetched yet
+            if n == 0:
                 return _TITLE_BOOST_EMPTY
-            if n < _SHORT_PAGE_THRESHOLD:  # short page
+            if n < _SHORT_PAGE_THRESHOLD:
                 return _TITLE_BOOST_SHORT
             return _TITLE_BOOST_LONG
 
-        def _calculate_md_score(doc: Doc, token: str) -> float:
-            """Calculate enhanced relevance score for Markdown content.
-
-            Args:
-                doc: Document to score
-                token: Search token to score against
-
-            Returns:
-                Weighted relevance score considering Markdown structure
-
-            Note:
-                Applies different weights to content types:
-                - Title matches: Variable boost (8x/5x/3x based on content length)
-                - Header matches: 4x weight
-                - Code matches: 2x weight
-                - Link text matches: 2x weight
-                - Body text: 1x weight (base)
-            """
+        def _calculate_md_weighted_tf(doc: Doc, token: str) -> float:
+            """Calculate Markdown-weighted term frequency."""
             content_lower = doc.content.lower()
             title_lower = doc.index_title.lower()
 
-            # Base content frequency
             content_tf = content_lower.count(token)
-
-            # Title matches (highest weight)
             title_tf = title_lower.count(token) * _title_boost_for(doc)
 
-            # Header matches (high weight)
             header_tf = 0
             for header in _MD_HEADER.findall(doc.content):
                 header_tf += header.lower().count(token) * 4
 
-            # Code block matches (medium weight for tech docs)
             code_tf = 0
             for code in _MD_CODE_BLOCK.findall(doc.content):
                 code_tf += code.lower().count(token) * 2
 
-            # Link text matches (medium weight)
             link_tf = 0
             for link in _MD_LINK_TEXT.findall(doc.content):
                 link_tf += link.lower().count(token) * 2
 
             return float(content_tf + title_tf + header_tf + code_tf + link_tf)
 
+        def _bm25_score(idx: int, doc: Doc, token: str, idf: float, avgdl: float) -> float:
+            """Calculate BM25 score for a token in a document."""
+            tf = _calculate_md_weighted_tf(doc, token)
+            if tf == 0:
+                return 0.0
+
+            # Use cached document length
+            doc_len = self._doc_lengths.get(idx, 1)
+            if doc_len == 0:
+                doc_len = 1
+
+            # BM25 formula
+            numerator = tf * (_BM25_K1 + 1)
+            denominator = tf + _BM25_K1 * (1 - _BM25_B + _BM25_B * (doc_len / avgdl))
+
+            return idf * (numerator / denominator)
+
         q_tokens = [t.lower() for t in _TOKEN.findall(query)]
         scores: Dict[int, float] = {}
         N = max(len(self.docs), 1)
+        avgdl = self._get_avgdl()
 
         for qt in q_tokens:
+            n = self.doc_frequency.get(qt, 0)
+            idf = math.log((N - n + 0.5) / (n + 0.5) + 1)
+
             for idx in self.doc_indices.get(qt, []):
                 d = self.docs[idx]
-                tf = _calculate_md_score(d, qt)
-                idf = math.log((N + 1) / (1 + self.doc_frequency.get(qt, 0))) + 1.0
-                scores[idx] = scores.get(idx, 0.0) + tf * idf
+                score = _bm25_score(idx, d, qt, idf, avgdl)
+                scores[idx] = scores.get(idx, 0.0) + score
 
         ranked = sorted(((score, self.docs[i]) for i, score in scores.items()), key=lambda x: x[0], reverse=True)
         return ranked[:k]

--- a/strands-mcp/tests/test_cache.py
+++ b/strands-mcp/tests/test_cache.py
@@ -1,0 +1,156 @@
+"""Tests for cache module hydration and prefetch functionality."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands_mcp_server.utils import cache, indexer
+from strands_mcp_server.utils.doc_fetcher import Page
+
+
+@pytest.fixture(autouse=True)
+def reset_cache_state():
+    """Reset cache module global state before each test."""
+    cache._INDEX = None
+    cache._URL_CACHE = {}
+    cache._URL_TITLES = {}
+    cache._LINKS_LOADED = False
+    cache._PREFETCH_STARTED = False
+    yield
+    cache._INDEX = None
+    cache._URL_CACHE = {}
+    cache._URL_TITLES = {}
+    cache._LINKS_LOADED = False
+    cache._PREFETCH_STARTED = False
+
+
+class TestEnsurePageIndexUpdate:
+    """Tests for ensure_page updating the index."""
+
+    def test_ensure_page_updates_index_with_content(self):
+        cache._INDEX = indexer.IndexSearch()
+        cache._URL_CACHE["https://strandsagents.com/test.md"] = None
+        doc = indexer.Doc(
+            uri="https://strandsagents.com/test.md",
+            display_title="Test Doc",
+            content="",
+            index_title="test doc",
+        )
+        cache._INDEX.add(doc)
+
+        results_before = cache._INDEX.search("guardrail")
+        assert len(results_before) == 0
+
+        mock_raw = MagicMock()
+        mock_raw.title = "Test Doc"
+        mock_raw.content = "This document explains guardrail implementation patterns."
+
+        with patch("strands_mcp_server.utils.cache.doc_fetcher.fetch_and_clean", return_value=mock_raw):
+            with patch("strands_mcp_server.utils.cache.text_processor.format_display_title", return_value="Test Doc"):
+                page = cache.ensure_page("https://strandsagents.com/test.md")
+
+        assert page is not None
+        assert page.content == mock_raw.content
+
+        results_after = cache._INDEX.search("guardrail")
+        assert len(results_after) == 1
+        assert results_after[0][1].uri == "https://strandsagents.com/test.md"
+
+    def test_ensure_page_idempotent_on_cached(self):
+        cached_page = Page(url="https://example.com/cached", title="Cached", content="content")
+        cache._URL_CACHE["https://example.com/cached"] = cached_page
+
+        with patch("strands_mcp_server.utils.cache.doc_fetcher.fetch_and_clean") as mock_fetch:
+            result = cache.ensure_page("https://example.com/cached")
+
+        assert result is cached_page
+        mock_fetch.assert_not_called()
+
+    def test_ensure_page_handles_fetch_failure(self):
+        cache._URL_CACHE["https://example.com/fail"] = None
+
+        with patch(
+            "strands_mcp_server.utils.cache.doc_fetcher.fetch_and_clean", side_effect=Exception("Network error")
+        ):
+            result = cache.ensure_page("https://example.com/fail")
+
+        assert result is None
+
+
+class TestPrefetchEnvVar:
+    """Tests for background prefetch environment variable."""
+
+    def test_prefetch_disabled_by_default(self):
+        with patch.dict(os.environ, {}, clear=True):
+            if cache.PREFETCH_ENV_VAR in os.environ:
+                del os.environ[cache.PREFETCH_ENV_VAR]
+            assert cache._is_prefetch_enabled() is False
+
+    def test_prefetch_enabled_with_1(self):
+        with patch.dict(os.environ, {cache.PREFETCH_ENV_VAR: "1"}):
+            assert cache._is_prefetch_enabled() is True
+
+    def test_prefetch_enabled_with_true(self):
+        with patch.dict(os.environ, {cache.PREFETCH_ENV_VAR: "true"}):
+            assert cache._is_prefetch_enabled() is True
+
+    def test_prefetch_enabled_with_yes(self):
+        with patch.dict(os.environ, {cache.PREFETCH_ENV_VAR: "yes"}):
+            assert cache._is_prefetch_enabled() is True
+
+    def test_prefetch_disabled_with_other_values(self):
+        with patch.dict(os.environ, {cache.PREFETCH_ENV_VAR: "0"}):
+            assert cache._is_prefetch_enabled() is False
+
+        with patch.dict(os.environ, {cache.PREFETCH_ENV_VAR: "false"}):
+            assert cache._is_prefetch_enabled() is False
+
+        with patch.dict(os.environ, {cache.PREFETCH_ENV_VAR: "no"}):
+            assert cache._is_prefetch_enabled() is False
+
+
+class TestBackgroundPrefetch:
+    """Tests for background prefetch functionality."""
+
+    def test_start_prefetch_only_when_enabled(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("strands_mcp_server.utils.cache.threading.Thread") as mock_thread:
+                cache._start_background_prefetch()
+                mock_thread.assert_not_called()
+
+    def test_start_prefetch_when_enabled(self):
+        with patch.dict(os.environ, {cache.PREFETCH_ENV_VAR: "1"}):
+            with patch("strands_mcp_server.utils.cache.threading.Thread") as mock_thread:
+                mock_instance = MagicMock()
+                mock_thread.return_value = mock_instance
+
+                cache._start_background_prefetch()
+
+                mock_thread.assert_called_once()
+                mock_instance.start.assert_called_once()
+
+    def test_start_prefetch_idempotent(self):
+        with patch.dict(os.environ, {cache.PREFETCH_ENV_VAR: "1"}):
+            with patch("strands_mcp_server.utils.cache.threading.Thread") as mock_thread:
+                mock_instance = MagicMock()
+                mock_thread.return_value = mock_instance
+
+                cache._start_background_prefetch()
+                cache._start_background_prefetch()
+                cache._start_background_prefetch()
+
+                assert mock_thread.call_count == 1
+
+    def test_load_links_only_triggers_prefetch_when_enabled(self):
+        with patch.dict(os.environ, {cache.PREFETCH_ENV_VAR: "1"}):
+            with patch("strands_mcp_server.utils.cache.doc_fetcher.parse_llms_txt", return_value=[]):
+                with patch("strands_mcp_server.utils.cache.doc_config") as mock_config:
+                    mock_config.llm_texts_url = []
+                    with patch("strands_mcp_server.utils.cache.threading.Thread") as mock_thread:
+                        mock_instance = MagicMock()
+                        mock_thread.return_value = mock_instance
+
+                        cache.load_links_only()
+
+                        mock_thread.assert_called_once()

--- a/strands-mcp/tests/test_concurrency_blockers.py
+++ b/strands-mcp/tests/test_concurrency_blockers.py
@@ -521,3 +521,126 @@ class TestBlocker2CacheBeforeIndexing:
         # Term should be searchable
         results = cache._INDEX.search("flakyterm")
         assert len(results) == 1
+
+
+class TestItem3ReRankAfterHydration:
+    """Reproduce ITEM 3: search returns inconsistent scores when hydration changes index.
+
+    The bug: search_docs() ranks results, then hydrates top-k (calling ensure_page()
+    which calls update_content()), but the returned scores are from BEFORE hydration.
+    The first response mixes pre-hydration ranking with post-hydration snippets.
+
+    Bot repro: first response tied 0.384 with hydrated snippets; identical second
+    query ranked 0.435/0.244 (consistent with hydrated content).
+
+    Fix: After hydrating top-k, if any page's content actually changed, re-run
+    the ranking and return re-ranked results.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_cache_state(self):
+        """Reset cache module global state before each test."""
+        cache._INDEX = None
+        cache._URL_CACHE = {}
+        cache._URL_TITLES = {}
+        cache._LINKS_LOADED = False
+        cache._PREFETCH_STARTED = False
+        yield
+        cache._INDEX = None
+        cache._URL_CACHE = {}
+        cache._URL_TITLES = {}
+        cache._LINKS_LOADED = False
+        cache._PREFETCH_STARTED = False
+
+    def test_first_search_matches_second_search_after_hydration(self):
+        """First search after hydration must return same scores as immediate second search.
+
+        Scenario:
+        1. Two docs indexed with empty content (title-only)
+        2. Doc A's content will have strong match for query term (high TF)
+        3. Doc B's content will have weak match for query term (low TF)
+        4. BEFORE hydration: both have empty content, scores based on title only
+        5. First search triggers hydration of top results
+        6. BUG: First search returns pre-hydration scores but post-hydration snippets
+        7. Second identical search returns correct post-hydration scores
+
+        The assertion: first search scores == second search scores (consistent state)
+        """
+        from strands_mcp_server.server import search_docs
+
+        # Setup: create index with two docs, empty content
+        cache._INDEX = indexer.IndexSearch()
+
+        url_a = "https://strandsagents.com/doc_a.md"
+        url_b = "https://strandsagents.com/doc_b.md"
+
+        # Both docs have "guardrail" in title for initial ranking
+        doc_a = indexer.Doc(
+            uri=url_a,
+            display_title="Guardrail Safety Guide",
+            content="",  # Empty - will be hydrated
+            index_title="guardrail safety guide",
+        )
+        doc_b = indexer.Doc(
+            uri=url_b,
+            display_title="Guardrail Overview",
+            content="",  # Empty - will be hydrated
+            index_title="guardrail overview",
+        )
+        cache._INDEX.add(doc_a)
+        cache._INDEX.add(doc_b)
+
+        # Set up cache placeholders
+        cache._URL_CACHE[url_a] = None
+        cache._URL_CACHE[url_b] = None
+        cache._URL_TITLES[url_a] = "Guardrail Safety Guide"
+        cache._URL_TITLES[url_b] = "Guardrail Overview"
+        cache._LINKS_LOADED = True
+
+        # Mock fetch to return different content for each doc
+        # Doc A: many occurrences of "guardrail" -> should rank higher after hydration
+        # Doc B: few occurrences of "guardrail" -> should rank lower after hydration
+        def mock_fetch(url):
+            mock_raw = MagicMock()
+            if url == url_a:
+                mock_raw.title = "Guardrail Safety Guide"
+                # Strong match: many guardrail mentions
+                mock_raw.content = (
+                    "# Guardrail Safety Guide\n\n"
+                    "This is the guardrail documentation. Guardrails are important. "
+                    "Use guardrails to ensure safety. Guardrail configuration is key. "
+                    "The guardrail system provides guardrail protection with guardrail validation."
+                )
+            else:
+                mock_raw.title = "Guardrail Overview"
+                # Weak match: one guardrail mention
+                mock_raw.content = "# Guardrail Overview\n\nThis is a brief overview. See other docs for details."
+            return mock_raw
+
+        with patch("strands_mcp_server.utils.cache.doc_fetcher.fetch_and_clean", side_effect=mock_fetch):
+            with patch(
+                "strands_mcp_server.utils.cache.text_processor.format_display_title",
+                side_effect=lambda url, title, titles: title,
+            ):
+                # First search: triggers hydration
+                results_first = search_docs(query="guardrail", k=5)
+
+                # Second search: should return identical scores if fix is applied
+                results_second = search_docs(query="guardrail", k=5)
+
+        # Extract scores for comparison
+        scores_first = {r["url"]: r["score"] for r in results_first}
+        scores_second = {r["url"]: r["score"] for r in results_second}
+
+        # BUG ASSERTION: Before fix, first search returns stale pre-hydration scores
+        # After fix, first search should return same scores as second search
+        assert scores_first == scores_second, (
+            f"INCONSISTENT STATE: First search returned different scores than second search.\n"
+            f"First search scores: {scores_first}\n"
+            f"Second search scores: {scores_second}\n"
+            f"This indicates first search returned pre-hydration ranking with post-hydration snippets."
+        )
+
+        # Verify hydration actually happened (scores should differ from title-only)
+        # Note: The specific ranking order depends on BM25 tuning, not the consistency fix
+        assert len(results_first) == 2, "Expected 2 results"

--- a/strands-mcp/tests/test_concurrency_blockers.py
+++ b/strands-mcp/tests/test_concurrency_blockers.py
@@ -18,6 +18,178 @@ import pytest
 from strands_mcp_server.utils import cache, indexer
 
 
+class TestBlocker1DeterministicRace:
+    """Deterministic reproduction of BLOCKER 1: race in read-modify-write on doc_frequency.
+
+    Uses the _TEST_YIELD hook to force interleaving at the critical seam:
+        current_df = doc_frequency.get(tok, 0)  # READ
+        _TEST_YIELD()                            # <-- forced context switch
+        doc_frequency[tok] = current_df + 1     # WRITE
+
+    Without the lock, both threads read the same value (0), then both write 1.
+    With the lock, operations are serialized, so no race occurs.
+
+    This test MUST FAIL when the lock is removed/bypassed.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_test_yield(self):
+        """Ensure _TEST_YIELD is None before and after each test."""
+        indexer._TEST_YIELD = None
+        yield
+        indexer._TEST_YIELD = None
+
+    def test_deterministic_lost_increment_via_forced_interleaving(self):
+        """Force two threads to interleave at the read-modify-write seam.
+
+        Scenario WITHOUT lock:
+        - Thread A reads doc_frequency["racetoken"]=0, then yields at barrier
+        - Thread B reads doc_frequency["racetoken"]=0 (same!), then yields
+        - Both threads pass barrier
+        - Thread A writes doc_frequency["racetoken"]=1
+        - Thread B writes doc_frequency["racetoken"]=1  (LOST INCREMENT!)
+
+        Expected with lock: doc_frequency["racetoken"]=2, postings=[0,1]
+        Expected WITHOUT lock: doc_frequency["racetoken"]=1, postings=[0,1] (CORRUPTION)
+
+        The invariant df == len(postings) catches this.
+        """
+        # Use threading primitives to force interleaving
+        barrier = threading.Barrier(2, timeout=2)
+        thread_count_at_seam = [0]
+        seam_lock = threading.Lock()
+
+        def yield_at_seam():
+            """Called between read and write in the critical section.
+
+            With proper locking, only one thread enters the critical section at a time,
+            so the barrier will timeout (one waiter, never reaches 2).
+
+            Without locking, both threads can be in the critical section simultaneously,
+            both reach the barrier, and pass through - exposing the race.
+            """
+            with seam_lock:
+                thread_count_at_seam[0] += 1
+            try:
+                barrier.wait()  # Will timeout if only one thread reaches here
+            except threading.BrokenBarrierError:
+                pass  # Expected when lock serializes access
+
+        indexer._TEST_YIELD = yield_at_seam
+
+        idx = indexer.IndexSearch()
+        errors = []
+
+        doc_a = indexer.Doc(
+            uri="https://example.com/a",
+            display_title="Doc A",
+            content="racetoken",
+            index_title="doc a",
+        )
+        doc_b = indexer.Doc(
+            uri="https://example.com/b",
+            display_title="Doc B",
+            content="racetoken",
+            index_title="doc b",
+        )
+
+        def add_doc_a():
+            try:
+                idx.add(doc_a)
+            except threading.BrokenBarrierError:
+                pass  # Expected when lock serializes
+            except Exception as e:
+                errors.append(e)
+
+        def add_doc_b():
+            try:
+                idx.add(doc_b)
+            except threading.BrokenBarrierError:
+                pass  # Expected when lock serializes
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=add_doc_a)
+        t2 = threading.Thread(target=add_doc_b)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        assert not errors, f"Threads raised unexpected exceptions: {errors}"
+
+        # INTEGRITY CHECK: df must equal len(postings)
+        df = idx.doc_frequency.get("racetoken", 0)
+        postings = idx.doc_indices.get("racetoken", [])
+
+        # With proper locking, both increments are serialized: df=2, postings=[0,1]
+        # Without locking + forced interleaving: df=1, postings=[0,1] → CORRUPTION
+        assert df == len(postings), (
+            f"RACE DETECTED: doc_frequency['racetoken']={df} != len(postings)={len(postings)}. "
+            f"Lost increment due to unserialized read-modify-write. Postings: {postings}"
+        )
+        assert df == 2, (
+            f"Expected df=2 (both docs indexed), got df={df}. Lost increment indicates missing lock protection."
+        )
+
+    def test_deterministic_race_with_many_threads(self):
+        """Stress variant: many threads all racing on the same token.
+
+        With N threads each adding a doc with "stresstoken", expected df=N.
+        Without locking + forced interleaving, many increments will be lost.
+        """
+        num_threads = 10
+        barrier = threading.Barrier(num_threads, timeout=2)
+
+        def yield_at_seam():
+            try:
+                barrier.wait()
+            except threading.BrokenBarrierError:
+                pass  # Expected when lock serializes access
+
+        indexer._TEST_YIELD = yield_at_seam
+
+        idx = indexer.IndexSearch()
+        errors = []
+
+        docs = [
+            indexer.Doc(
+                uri=f"https://example.com/stress{i}",
+                display_title=f"Stress Doc {i}",
+                content="stresstoken",
+                index_title=f"stress doc {i}",
+            )
+            for i in range(num_threads)
+        ]
+
+        def add_doc(doc):
+            try:
+                idx.add(doc)
+            except threading.BrokenBarrierError:
+                pass  # Expected when lock serializes
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=add_doc, args=(docs[i],)) for i in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert not errors, f"Threads raised unexpected exceptions: {errors}"
+
+        df = idx.doc_frequency.get("stresstoken", 0)
+        postings = idx.doc_indices.get("stresstoken", [])
+
+        # Critical invariant: df == len(postings)
+        assert df == len(postings), (
+            f"RACE DETECTED: df={df} != len(postings)={len(postings)}. "
+            f"Lost {len(postings) - df} increments due to concurrent read-modify-write."
+        )
+        # All N docs should be counted
+        assert df == num_threads, f"Expected df={num_threads}, got df={df}. Lost {num_threads - df} increments."
+
+
 class TestBlocker1ConcurrentIndexCorruption:
     """Reproduce BLOCKER 1: concurrent add/update_content corrupts index integrity.
 

--- a/strands-mcp/tests/test_concurrency_blockers.py
+++ b/strands-mcp/tests/test_concurrency_blockers.py
@@ -1,0 +1,351 @@
+"""Reproduction tests for PR #40 blockers.
+
+These tests reproduce the race conditions identified by the review bot.
+Per REVIEW-PROTOCOL.md Lesson 4: "Reproduce, don't reason" - these tests
+MUST fail on the unfixed code before we fix the issues.
+
+BLOCKER 1: Unlocked read-modify-write on shared index state
+BLOCKER 2: Page cached before indexing succeeds
+"""
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands_mcp_server.utils import cache, indexer
+
+
+class TestBlocker1ConcurrentIndexCorruption:
+    """Reproduce BLOCKER 1: concurrent add/update_content corrupts index integrity.
+
+    The bot demonstrated: 60 postings → df=48 (lost increments), same-URI duplication
+    (N=1, df=2, postings [0,0], negative BM25).
+
+    Note: The primary demonstration of this bug is through stress testing. Python's GIL
+    makes pure-Python races hard to reproduce deterministically, but the lack of locking
+    means the code is NOT thread-safe. Adding a Lock is the correct fix regardless of
+    whether tests can reliably trigger the race in CI.
+
+    These tests verify the INTERFACE contract: that concurrent operations preserve
+    index integrity invariants (df == len(postings), no duplicate postings, df <= N).
+    """
+
+    def test_concurrent_add_preserves_integrity_invariants(self):
+        """Concurrent add() calls must preserve: df == len(postings), df <= N.
+
+        Without locking, concurrent increments to doc_frequency[token] can be lost:
+        Thread A reads df=5, Thread B reads df=5, both write df=6 → lost increment.
+
+        The fix (threading.Lock) ensures these invariants hold under concurrent access.
+        """
+        index = indexer.IndexSearch()
+        num_docs = 100
+        num_threads = 10
+
+        # All docs share this token so they all increment doc_frequency["shared"]
+        docs = [
+            indexer.Doc(
+                uri=f"https://example.com/doc{i}",
+                display_title=f"Doc {i}",
+                content="shared token here unique" + str(i),
+                index_title=f"doc {i}",
+            )
+            for i in range(num_docs)
+        ]
+
+        def add_batch(start, end):
+            for i in range(start, end):
+                index.add(docs[i])
+
+        # Concurrent adds
+        batch_size = num_docs // num_threads
+        with ThreadPoolExecutor(max_workers=num_threads) as executor:
+            futures = [executor.submit(add_batch, i * batch_size, (i + 1) * batch_size) for i in range(num_threads)]
+            for f in as_completed(futures):
+                f.result()
+
+        # INTEGRITY INVARIANTS that must hold after concurrent operations:
+        actual_df = index.doc_frequency.get("shared", 0)
+        actual_postings = len(index.doc_indices.get("shared", []))
+        actual_N = len(index.docs)
+
+        # Invariant 1: df must equal len(postings) for each token
+        assert actual_df == actual_postings, (
+            f"Invariant violated: df ({actual_df}) != len(postings) ({actual_postings})"
+        )
+        # Invariant 2: df must not exceed N
+        assert actual_df <= actual_N, f"Invariant violated: df ({actual_df}) > N ({actual_N})"
+        # Invariant 3: N must equal expected (no lost docs)
+        assert actual_N == num_docs, f"docs list corrupted: expected {num_docs}, got {actual_N}"
+        # Invariant 4: all docs added, so df should equal N for 'shared'
+        assert actual_df == num_docs, f"doc_frequency lost increments: expected {num_docs}, got {actual_df}"
+
+    def test_concurrent_update_content_preserves_integrity_invariants(self):
+        """Concurrent update_content() calls must preserve index integrity.
+
+        Scenario: prefetch daemon thread + foreground ensure_page() both call
+        update_content() on the same or different URIs concurrently.
+
+        Without locking, the interleaving of:
+        1. read old_tokens
+        2. compute new_tokens
+        3. update doc_frequency (decrement for removed, increment for added)
+        4. update doc_indices (remove idx from old, add to new)
+        can corrupt the index.
+        """
+        index = indexer.IndexSearch()
+        num_docs = 50
+
+        # Add docs with empty content
+        for i in range(num_docs):
+            doc = indexer.Doc(
+                uri=f"https://example.com/page{i}",
+                display_title=f"Page {i}",
+                content="",
+                index_title=f"page {i}",
+            )
+            index.add(doc)
+
+        barrier = threading.Barrier(2)
+        errors = []
+
+        def updater_a():
+            """Simulates prefetch daemon."""
+            try:
+                barrier.wait(timeout=5)
+                for i in range(num_docs):
+                    index.update_content(f"https://example.com/page{i}", f"hydrated content alpha doc{i}")
+            except Exception as e:
+                errors.append(e)
+
+        def updater_b():
+            """Simulates foreground ensure_page."""
+            try:
+                barrier.wait(timeout=5)
+                for i in range(num_docs):
+                    index.update_content(f"https://example.com/page{i}", f"hydrated content alpha doc{i}")
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=updater_a)
+        t2 = threading.Thread(target=updater_b)
+        t1.start()
+        t2.start()
+        t1.join(timeout=30)
+        t2.join(timeout=30)
+
+        assert not errors, f"Exceptions during concurrent update: {errors}"
+
+        # INTEGRITY INVARIANTS after concurrent updates:
+        alpha_df = index.doc_frequency.get("alpha", 0)
+        alpha_postings = index.doc_indices.get("alpha", [])
+
+        # Invariant 1: df == len(postings)
+        assert alpha_df == len(alpha_postings), (
+            f"Invariant violated: df ({alpha_df}) != len(postings) ({len(alpha_postings)})"
+        )
+        # Invariant 2: no duplicate indices in postings
+        assert len(alpha_postings) == len(set(alpha_postings)), "Invariant violated: duplicate indices in postings list"
+        # Invariant 3: df should equal num_docs (all docs have 'alpha')
+        assert alpha_df == num_docs, f"doc_frequency corrupted: expected {num_docs}, got {alpha_df}"
+
+    def test_concurrent_operations_never_produce_negative_bm25(self):
+        """Concurrent add() + update_content() must never produce negative BM25 scores.
+
+        The bot showed: race conditions can lead to df > N (same-URI duplication in
+        postings), which makes IDF = log((N - df + 0.5) / (df + 0.5) + 1) negative
+        when df > N, producing negative BM25 scores.
+        """
+        index = indexer.IndexSearch()
+
+        # Add initial doc
+        doc = indexer.Doc(
+            uri="https://example.com/race",
+            display_title="Race Doc",
+            content="",
+            index_title="race doc",
+        )
+        index.add(doc)
+
+        barrier = threading.Barrier(3)
+        negative_scores = []
+
+        def adder():
+            """Add more docs concurrently."""
+            barrier.wait(timeout=5)
+            for i in range(20):
+                new_doc = indexer.Doc(
+                    uri=f"https://example.com/new{i}",
+                    display_title=f"New {i}",
+                    content="commonterm specialword",
+                    index_title=f"new {i}",
+                )
+                index.add(new_doc)
+
+        def updater():
+            """Update existing doc concurrently."""
+            barrier.wait(timeout=5)
+            for _ in range(20):
+                index.update_content("https://example.com/race", "commonterm updated content")
+                time.sleep(0.001)
+
+        def searcher():
+            """Search during mutations and record any negative scores."""
+            barrier.wait(timeout=5)
+            for _ in range(20):
+                results = index.search("commonterm")
+                for score, doc in results:
+                    if score < 0:
+                        negative_scores.append((score, doc.uri))
+                time.sleep(0.001)
+
+        threads = [
+            threading.Thread(target=adder),
+            threading.Thread(target=updater),
+            threading.Thread(target=searcher),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        # No negative BM25 scores should have been observed
+        assert not negative_scores, f"Negative BM25 scores observed: {negative_scores[:5]}"
+
+        # Final integrity check: verify all invariants hold
+        N = len(index.docs)
+        for token, df in index.doc_frequency.items():
+            postings = index.doc_indices.get(token, [])
+            # Invariant: df == len(postings)
+            assert df == len(postings), f"Invariant violated for {token}: df={df}, len(postings)={len(postings)}"
+            # Invariant: df <= N
+            assert df <= N, f"Invariant violated: doc_frequency[{token}]={df} exceeds N={N}"
+
+
+class TestBlocker2CacheBeforeIndexing:
+    """Reproduce BLOCKER 2: page cached before indexing succeeds.
+
+    If update_content() raises, the page is already in _URL_CACHE, so subsequent
+    calls return the cached page and never retry indexing → body search permanently empty.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_cache_state(self):
+        """Reset cache module global state before each test."""
+        cache._INDEX = None
+        cache._URL_CACHE = {}
+        cache._URL_TITLES = {}
+        cache._LINKS_LOADED = False
+        cache._PREFETCH_STARTED = False
+        yield
+        cache._INDEX = None
+        cache._URL_CACHE = {}
+        cache._URL_TITLES = {}
+        cache._LINKS_LOADED = False
+        cache._PREFETCH_STARTED = False
+
+    def test_indexing_failure_leaves_page_unsearchable_forever(self):
+        """When update_content raises, the page should NOT be cached (or should be retryable).
+
+        Current bug: page is assigned to _URL_CACHE BEFORE update_content() is called.
+        If update_content() raises, the page is cached but body terms are not indexed.
+        Subsequent calls return the cached page, never retrying indexing.
+        """
+        # Setup: index with a doc that has empty content
+        cache._INDEX = indexer.IndexSearch()
+        url = "https://strandsagents.com/broken.md"
+        cache._URL_CACHE[url] = None
+
+        doc = indexer.Doc(
+            uri=url,
+            display_title="Broken Doc",
+            content="",
+            index_title="broken doc",
+        )
+        cache._INDEX.add(doc)
+
+        # Verify: "specialterm" not yet searchable
+        results_before = cache._INDEX.search("specialterm")
+        assert len(results_before) == 0
+
+        # Mock fetch to succeed but update_content to fail
+        mock_raw = MagicMock()
+        mock_raw.title = "Broken Doc"
+        mock_raw.content = "This has specialterm that should be searchable."
+
+        call_count = [0]
+        original_update = cache._INDEX.update_content
+
+        def failing_update(uri, content):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("Simulated indexing failure")
+            return original_update(uri, content)
+
+        with patch("strands_mcp_server.utils.cache.doc_fetcher.fetch_and_clean", return_value=mock_raw):
+            with patch("strands_mcp_server.utils.cache.text_processor.format_display_title", return_value="Broken Doc"):
+                with patch.object(cache._INDEX, "update_content", side_effect=failing_update):
+                    # First call: fetch succeeds, indexing fails
+                    cache.ensure_page(url)
+
+        # The page should either be None (not cached) or retriable
+        # Current bug: page1 is not None because it was cached before indexing
+
+        # Second call: should retry indexing, not return stale cached page
+        with patch("strands_mcp_server.utils.cache.doc_fetcher.fetch_and_clean", return_value=mock_raw):
+            with patch("strands_mcp_server.utils.cache.text_processor.format_display_title", return_value="Broken Doc"):
+                # This time update_content should succeed (call_count[0] > 1)
+                cache.ensure_page(url)
+
+        # After retry, the term should be searchable
+        results_after = cache._INDEX.search("specialterm")
+        assert len(results_after) == 1, (
+            f"Body term 'specialterm' not searchable after retry - "
+            f"page was cached before indexing and never retried. "
+            f"Got {len(results_after)} results."
+        )
+
+    def test_fetch_failure_does_not_cache_none(self):
+        """When fetch_and_clean raises, the URL should remain retryable (cache stays None)."""
+        cache._INDEX = indexer.IndexSearch()
+        url = "https://strandsagents.com/flaky.md"
+        cache._URL_CACHE[url] = None
+
+        doc = indexer.Doc(
+            uri=url,
+            display_title="Flaky Doc",
+            content="",
+            index_title="flaky doc",
+        )
+        cache._INDEX.add(doc)
+
+        call_count = [0]
+
+        def flaky_fetch(u):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise ConnectionError("Network flake")
+            mock_raw = MagicMock()
+            mock_raw.title = "Flaky Doc"
+            mock_raw.content = "flakyterm content here"
+            return mock_raw
+
+        with patch("strands_mcp_server.utils.cache.doc_fetcher.fetch_and_clean", side_effect=flaky_fetch):
+            with patch("strands_mcp_server.utils.cache.text_processor.format_display_title", return_value="Flaky Doc"):
+                # First call: fetch fails
+                page1 = cache.ensure_page(url)
+                assert page1 is None
+
+                # Cache should still be None so retry is possible
+                assert cache._URL_CACHE.get(url) is None, "Failed fetch should not populate cache"
+
+                # Second call: fetch succeeds
+                page2 = cache.ensure_page(url)
+                assert page2 is not None
+
+        # Term should be searchable
+        results = cache._INDEX.search("flakyterm")
+        assert len(results) == 1

--- a/strands-mcp/tests/test_indexer.py
+++ b/strands-mcp/tests/test_indexer.py
@@ -1,0 +1,296 @@
+"""Tests for the indexer module with BM25 scoring and content hydration."""
+
+from strands_mcp_server.utils.indexer import Doc, IndexSearch
+
+
+class TestIndexerBasic:
+    """Basic indexer functionality tests."""
+
+    def test_add_and_search_simple(self):
+        index = IndexSearch()
+        doc = Doc(
+            uri="https://example.com/test",
+            display_title="Test Doc",
+            content="hello world",
+            index_title="test doc",
+        )
+        index.add(doc)
+
+        results = index.search("hello")
+
+        assert len(results) == 1
+        assert results[0][1].uri == "https://example.com/test"
+
+    def test_search_returns_empty_for_no_match(self):
+        index = IndexSearch()
+        doc = Doc(
+            uri="https://example.com/test",
+            display_title="Test Doc",
+            content="hello world",
+            index_title="test doc",
+        )
+        index.add(doc)
+
+        results = index.search("nonexistent")
+
+        assert len(results) == 0
+
+    def test_title_search_ranks_higher(self):
+        index = IndexSearch()
+        doc1 = Doc(
+            uri="https://example.com/body",
+            display_title="Other Topic",
+            content="This document discusses guardrail implementation details.",
+            index_title="other topic",
+        )
+        doc2 = Doc(
+            uri="https://example.com/title",
+            display_title="Guardrail Guide",
+            content="This is a guide about safety mechanisms.",
+            index_title="guardrail guide",
+        )
+        index.add(doc1)
+        index.add(doc2)
+
+        results = index.search("guardrail")
+
+        assert len(results) == 2
+        assert results[0][1].uri == "https://example.com/title"
+
+
+class TestContentHydration:
+    """Tests for content hydration and index updates."""
+
+    def test_body_only_terms_found_after_hydration(self):
+        # Core fix for issue #3321: body-only terms become searchable after hydration
+        index = IndexSearch()
+
+        doc = Doc(
+            uri="https://strandsagents.com/guardrails.md",
+            display_title="Safety Guide",
+            content="",
+            index_title="safety guide",
+        )
+        index.add(doc)
+
+        results_before = index.search("guardrail")
+        assert len(results_before) == 0
+
+        new_content = """# Safety Guide
+
+## Guardrails
+
+Guardrails help protect your agent from harmful outputs. You can configure
+custom guardrail policies to filter content.
+
+### Setting up guardrails
+
+Use the guardrail configuration to define rules.
+"""
+        updated = index.update_content("https://strandsagents.com/guardrails.md", new_content)
+        assert updated is True
+
+        results_after = index.search("guardrail")
+        assert len(results_after) == 1
+        assert results_after[0][1].uri == "https://strandsagents.com/guardrails.md"
+
+    def test_idempotent_rehydration(self):
+        index = IndexSearch()
+
+        doc = Doc(
+            uri="https://example.com/test",
+            display_title="Test",
+            content="",
+            index_title="test",
+        )
+        index.add(doc)
+
+        content = "This is the test content with unique terms."
+
+        index.update_content("https://example.com/test", content)
+        results1 = index.search("unique")
+        score1 = results1[0][0] if results1 else 0
+
+        index.update_content("https://example.com/test", content)
+        results2 = index.search("unique")
+        score2 = results2[0][0] if results2 else 0
+
+        assert len(results1) == len(results2)
+        assert score1 == score2
+
+    def test_update_content_returns_false_for_unknown_uri(self):
+        index = IndexSearch()
+        result = index.update_content("https://unknown.com/page", "content")
+        assert result is False
+
+    def test_hydration_removes_old_tokens(self):
+        index = IndexSearch()
+
+        doc = Doc(
+            uri="https://example.com/test",
+            display_title="Test",
+            content="apple banana cherry",
+            index_title="test",
+        )
+        index.add(doc)
+
+        assert len(index.search("apple")) == 1
+
+        index.update_content("https://example.com/test", "orange grape melon")
+
+        assert len(index.search("apple")) == 0
+        assert len(index.search("orange")) == 1
+
+
+class TestBM25Scoring:
+    """Tests for BM25 scoring behavior."""
+
+    def test_bm25_length_normalization(self):
+        index = IndexSearch()
+
+        short_doc = Doc(
+            uri="https://example.com/short",
+            display_title="Short",
+            content="Learn python quickly.",
+            index_title="short",
+        )
+        long_doc = Doc(
+            uri="https://example.com/long",
+            display_title="Long",
+            content="Learn python " + "word " * 500 + "end.",
+            index_title="long",
+        )
+        index.add(short_doc)
+        index.add(long_doc)
+
+        results = index.search("python")
+
+        assert len(results) == 2
+        assert results[0][1].uri == "https://example.com/short"
+        assert results[0][0] > results[1][0]
+
+    def test_markdown_header_boost_preserved(self):
+        index = IndexSearch()
+
+        header_doc = Doc(
+            uri="https://example.com/header",
+            display_title="Guide",
+            content="# Introduction\n\n## Streaming\n\nContent here.",
+            index_title="guide",
+        )
+        body_doc = Doc(
+            uri="https://example.com/body",
+            display_title="Other",
+            content="# Other Topic\n\nWe discuss streaming in this paragraph.",
+            index_title="other",
+        )
+        index.add(header_doc)
+        index.add(body_doc)
+
+        results = index.search("streaming")
+
+        assert len(results) == 2
+        assert results[0][1].uri == "https://example.com/header"
+
+    def test_markdown_code_boost_preserved(self):
+        index = IndexSearch()
+
+        code_doc = Doc(
+            uri="https://example.com/code",
+            display_title="Code Example",
+            content="# Example\n\n```python\nimport asyncio\n```\n\nText here.",
+            index_title="code example",
+        )
+        body_doc = Doc(
+            uri="https://example.com/text",
+            display_title="Text Only",
+            content="# Topic\n\nWe use asyncio for async programming asyncio is great.",
+            index_title="text only",
+        )
+        index.add(code_doc)
+        index.add(body_doc)
+
+        results = index.search("asyncio")
+
+        assert len(results) == 2
+
+    def test_title_queries_rank_titles_first(self):
+        index = IndexSearch()
+
+        title_doc = Doc(
+            uri="https://example.com/agent",
+            display_title="Agent Overview",
+            content="This describes the system architecture.",
+            index_title="agent overview",
+        )
+        body_doc = Doc(
+            uri="https://example.com/body",
+            display_title="System Design",
+            content="The agent handles requests. The agent logic is here.",
+            index_title="system design",
+        )
+        index.add(title_doc)
+        index.add(body_doc)
+
+        results = index.search("agent")
+
+        assert len(results) == 2
+        assert results[0][1].uri == "https://example.com/agent"
+
+
+class TestEdgeCases:
+    """Edge case tests."""
+
+    def test_empty_content_document(self):
+        index = IndexSearch()
+
+        doc = Doc(
+            uri="https://example.com/empty",
+            display_title="Empty Doc",
+            content="",
+            index_title="empty doc",
+        )
+        index.add(doc)
+
+        results = index.search("empty")
+        assert len(results) == 1
+
+    def test_search_on_empty_index(self):
+        index = IndexSearch()
+        results = index.search("anything")
+        assert results == []
+
+    def test_multiple_documents_same_term(self):
+        index = IndexSearch()
+
+        for i in range(5):
+            doc = Doc(
+                uri=f"https://example.com/doc{i}",
+                display_title=f"Doc {i}",
+                content=f"Common term appears here. Doc {i} specific content.",
+                index_title=f"doc {i}",
+            )
+            index.add(doc)
+
+        results = index.search("common")
+
+        assert len(results) == 5
+        for score, _doc in results:
+            assert score > 0
+
+    def test_case_insensitive_search(self):
+        index = IndexSearch()
+
+        doc = Doc(
+            uri="https://example.com/test",
+            display_title="Test",
+            content="Python PYTHON python PyThOn",
+            index_title="test",
+        )
+        index.add(doc)
+
+        results_lower = index.search("python")
+        results_upper = index.search("PYTHON")
+        results_mixed = index.search("PyThOn")
+
+        assert len(results_lower) == len(results_upper) == len(results_mixed) == 1


### PR DESCRIPTION
*Issue #, if available:*

Fixes strands-agents/harness-sdk#3321 (tracking: strands-agents/harness-sdk#3317)

*Description of changes:*

Search was title-only: docs are indexed at startup with empty content (`load_links_only()`), and `ensure_page()` cached fetched bodies without updating the index — so body-only queries ("guardrail", "temperature") returned nothing and the markdown-aware scoring in `indexer.py` was dead code.

Following the options laid out in the issue:

- `ensure_page()` now calls `IndexSearch.update_content()`, updating the indexed `Doc` and the inverted index when a page is hydrated (token-diff based, idempotent on re-hydration)
- BM25 scoring (k1=1.5, b=0.75, stdlib-only) replaces raw TF for length normalization, preserving the existing markdown multipliers (headers 4×, code 2×, link text 2×) and the title boost so exact-title queries keep their current top ranking
- Optional full prefetch behind `STRANDS_MCP_PREFETCH_ALL` (default OFF) for users who want full-text search immediately; search stays eventually-consistent while the background thread hydrates

Testing: 32 new tests (hydration indexing, idempotence, BM25 length normalization, title-rank preservation, prefetch flag); full suite 74/74 green; `hatch fmt --check` clean.

Note: happy to re-target this against harness-sdk after the monorepo move (harness-sdk#3300) if you'd rather take it there — the diff applies cleanly either way. #3331 (disk cache) planned as a follow-up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
