### PR TITLE
fix: negative cache failed fetches + cap no_sections fallback (fixes #3328, #3327)

### DIFF
--- a/strands-mcp/src/strands_mcp_server/server.py
+++ b/strands-mcp/src/strands_mcp_server/server.py
@@ -158,14 +158,23 @@ def fetch_doc(uri: str = "", section: str = "") -> Dict[str, Any]:
 
     sections = text_processor.parse_sections(page.content)
 
-    # No parseable sections: treat as small doc regardless of size
+    # No parseable sections: cap at SMALL_DOC_THRESHOLD to avoid
+    # dumping arbitrarily large documents into the model context.
     if not sections:
+        content = page.content
+        truncated = False
+        content_bytes = content.encode("utf-8")
+        if len(content_bytes) > text_processor.SMALL_DOC_THRESHOLD:
+            # Truncate at byte boundary, safely handling multi-byte chars
+            content = content_bytes[:text_processor.SMALL_DOC_THRESHOLD].decode("utf-8", errors="ignore")
+            truncated = True
         return {
             "url": uri,
             "title": page.title,
             "document_small": True,
             "reason": "no_sections",
-            "content": page.content,
+            "content": content,
+            **({"truncated": True} if truncated else {}),
         }
 
     # Section mode: extract specific section

--- a/strands-mcp/src/strands_mcp_server/utils/cache.py
+++ b/strands-mcp/src/strands_mcp_server/utils/cache.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from typing import Dict
 
 from ..config import doc_config
@@ -8,8 +10,12 @@ _INDEX: indexer.IndexSearch | None = None
 _URL_CACHE: Dict[str, doc_fetcher.Page | None] = {}  # url -> Page (None if not fetched yet)
 _URL_TITLES: Dict[str, str] = {}  # url -> curated title from llms.txt
 _LINKS_LOADED = False
+_FAILURE_CACHE: Dict[str, float] = {}  # url -> monotonic timestamp of last failure
+_FAILURE_TTL: float = 300.0  # seconds — retry a failed URL after this long
 
 SNIPPET_HYDRATE_MAX = 5  # how many top results to hydrate with content
+
+logger = logging.getLogger(__name__)
 
 
 def load_links_only() -> None:
@@ -58,6 +64,9 @@ def ensure_ready() -> None:
 def ensure_page(url: str) -> doc_fetcher.Page | None:
     """Ensure a page is cached, fetching it if necessary.
 
+    Failed fetches are negatively cached for ``_FAILURE_TTL`` seconds
+    to avoid repeated timeouts on the same broken URL.
+
     Args:
         url: The URL of the page to ensure is cached
 
@@ -65,6 +74,15 @@ def ensure_page(url: str) -> doc_fetcher.Page | None:
         The cached or newly fetched Page object, or None if fetch failed
 
     """
+    # Negative cache check — skip recently-failed URLs
+    failure_time = _FAILURE_CACHE.get(url)
+    if failure_time is not None:
+        if time.monotonic() - failure_time < _FAILURE_TTL:
+            logger.debug("Skipping recently-failed URL: %s (%.0fs ago)", url, time.monotonic() - failure_time)
+            return None
+        # TTL expired — retry
+        del _FAILURE_CACHE[url]
+
     page = _URL_CACHE.get(url)
     if page is not None:
         return page
@@ -74,7 +92,9 @@ def ensure_page(url: str) -> doc_fetcher.Page | None:
         page = doc_fetcher.Page(url=url, title=display_title, content=raw.content)
         _URL_CACHE[url] = page
         return page
-    except Exception:
+    except Exception as exc:
+        _FAILURE_CACHE[url] = time.monotonic()
+        logger.warning("Failed to fetch %s: %s: %s", url, type(exc).__name__, exc)
         return None
 
 


### PR DESCRIPTION
## Description

Two related fixes for the doc-fetch pipeline:

### Fix 1: Negative cache failed URL fetches (#3328)

`cache.ensure_page()` now:
- **Negatively caches failed fetches** with a 300s TTL — a 404/connection-error URL won't be retried on every `search_docs` call, eliminating repeated 30s timeouts
- **Logs the exception** with `logger.warning()` so operators can diagnose DNS, 404, and timeout failures instead of a silent `None` return

### Fix 2: Cap no_sections fallback at SMALL_DOC_THRESHOLD (#3327)

When `parse_sections()` finds no headers (e.g., large HTML pages that lose structure during `_html_to_text()` conversion), the `no_sections` fallback now:
- **Caps content at 8KB** (the existing `SMALL_DOC_THRESHOLD`) instead of returning the entire page
- **Signals truncation** with a `truncated: true` field in the response

## Related Issues

- Closes #3328
- Closes #3327

## Testing

- `pytest tests/` — 47 passed ✅
- Both fixes are in the doc-fetch path exercised by existing test coverage

## Pre-flight

- [x] Tests pass
- [x] Only 2 files changed (no generated files)
- [x] Single purpose per change
