### PR TITLE
fix: negatively cache failed fetches and cap no_sections content

### DIFF
--- a/strands-mcp/src/strands_mcp_server/server.py
+++ b/strands-mcp/src/strands_mcp_server/server.py
@@ -66,13 +66,16 @@ def search_docs(query: str, k: int = 5) -> List[Dict[str, Any]]:
     top = results[: min(len(results), cache.SNIPPET_HYDRATE_MAX)]
     for _, doc in top:
         cached = url_cache.get(doc.uri)
-        if cached is None or not cached.content:
+        if cached is None:
             cache.ensure_page(doc.uri)
 
     # Build response with real content snippets when available
     return_docs: List[Dict[str, Any]] = []
     for score, doc in results:
         page = url_cache.get(doc.uri)
+        # Guard against non-Page entries (failed sentinel) — treat as not fetched
+        if not hasattr(page, "content"):
+            page = None
         snippet = text_processor.make_snippet(page, doc.display_title)
         return_docs.append(
             {

--- a/strands-mcp/src/strands_mcp_server/server.py
+++ b/strands-mcp/src/strands_mcp_server/server.py
@@ -158,14 +158,22 @@ def fetch_doc(uri: str = "", section: str = "") -> Dict[str, Any]:
 
     sections = text_processor.parse_sections(page.content)
 
-    # No parseable sections: treat as small doc regardless of size
+    # No parseable sections: return bounded content to protect token budget
     if not sections:
+        content = page.content
+        threshold = text_processor.SMALL_DOC_THRESHOLD
+        encoded = content.encode("utf-8")
+        if len(encoded) > threshold:
+            trunc_msg = "\n\n… (truncated, no parseable sections)"
+            trunc_len = len(trunc_msg.encode("utf-8"))
+            # Re-encode from decoded string to avoid surrogates
+            content = encoded[:threshold - trunc_len].decode("utf-8", errors="ignore") + trunc_msg
         return {
             "url": uri,
             "title": page.title,
             "document_small": True,
             "reason": "no_sections",
-            "content": page.content,
+            "content": content,
         }
 
     # Section mode: extract specific section

--- a/strands-mcp/src/strands_mcp_server/utils/cache.py
+++ b/strands-mcp/src/strands_mcp_server/utils/cache.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import Any, Dict
 
 from ..config import doc_config
@@ -6,12 +7,32 @@ from . import doc_fetcher, indexer, text_processor
 
 logger = logging.getLogger(__name__)
 
-# Sentinel for negatively cached (failed) fetches — distinct from None (not fetched)
-_FAILED = object()
+# TTL for negatively cached (failed) fetches — transient failures are retried
+# after this duration
+_FAILED_TTL_SECONDS = 300  # 5 minutes
+
+
+class _FailedEntry:
+    """Sentinel for a negatively cached fetch failure with TTL expiry.
+
+    A page whose fetch failed is stored as a _FailedEntry instead of
+    being re-fetched immediately. Once TTL expires, the entry is treated
+    as stale and the next ensure_page call will retry the fetch.
+    """
+
+    __slots__ = ("_timestamp",)
+
+    def __init__(self) -> None:
+        self._timestamp = time.monotonic()
+
+    @property
+    def expired(self) -> bool:
+        return time.monotonic() - self._timestamp >= _FAILED_TTL_SECONDS
+
 
 # Global state
 _INDEX: indexer.IndexSearch | None = None
-_URL_CACHE: Dict[str, Any] = {}  # url -> Page, None (not fetched), or _FAILED (failed)
+_URL_CACHE: Dict[str, Any] = {}  # url -> Page, None (not fetched), or _FailedEntry (failed)
 _URL_TITLES: Dict[str, str] = {}  # url -> curated title from llms.txt
 _LINKS_LOADED = False
 
@@ -72,11 +93,16 @@ def ensure_page(url: str) -> doc_fetcher.Page | None:
 
     """
     cached = _URL_CACHE.get(url)
-    # Short-circuit on known failures — don't re-fetch
-    if cached is _FAILED:
-        return None
-    if cached is not None:
-        return cached
+    # Short-circuit on known transient failures — don't re-fetch
+    if isinstance(cached, _FailedEntry):
+        if cached.expired:
+            # TTL expired — clear and fall through to re-fetch
+            _URL_CACHE[url] = None
+        else:
+            return None
+    else:
+        if cached is not None:
+            return cached
     try:
         raw = doc_fetcher.fetch_and_clean(url)
         display_title = text_processor.format_display_title(url, raw.title, _URL_TITLES)
@@ -85,7 +111,7 @@ def ensure_page(url: str) -> doc_fetcher.Page | None:
         return page
     except Exception:
         logger.exception("Failed to fetch page: %s", url)
-        _URL_CACHE[url] = _FAILED  # negatively cache the failure
+        _URL_CACHE[url] = _FailedEntry()  # negatively cache the failure
         return None
 
 

--- a/strands-mcp/src/strands_mcp_server/utils/cache.py
+++ b/strands-mcp/src/strands_mcp_server/utils/cache.py
@@ -1,11 +1,17 @@
-from typing import Dict
+import logging
+from typing import Any, Dict
 
 from ..config import doc_config
 from . import doc_fetcher, indexer, text_processor
 
+logger = logging.getLogger(__name__)
+
+# Sentinel for negatively cached (failed) fetches — distinct from None (not fetched)
+_FAILED = object()
+
 # Global state
 _INDEX: indexer.IndexSearch | None = None
-_URL_CACHE: Dict[str, doc_fetcher.Page | None] = {}  # url -> Page (None if not fetched yet)
+_URL_CACHE: Dict[str, Any] = {}  # url -> Page, None (not fetched), or _FAILED (failed)
 _URL_TITLES: Dict[str, str] = {}  # url -> curated title from llms.txt
 _LINKS_LOADED = False
 
@@ -65,9 +71,12 @@ def ensure_page(url: str) -> doc_fetcher.Page | None:
         The cached or newly fetched Page object, or None if fetch failed
 
     """
-    page = _URL_CACHE.get(url)
-    if page is not None:
-        return page
+    cached = _URL_CACHE.get(url)
+    # Short-circuit on known failures — don't re-fetch
+    if cached is _FAILED:
+        return None
+    if cached is not None:
+        return cached
     try:
         raw = doc_fetcher.fetch_and_clean(url)
         display_title = text_processor.format_display_title(url, raw.title, _URL_TITLES)
@@ -75,6 +84,8 @@ def ensure_page(url: str) -> doc_fetcher.Page | None:
         _URL_CACHE[url] = page
         return page
     except Exception:
+        logger.exception("Failed to fetch page: %s", url)
+        _URL_CACHE[url] = _FAILED  # negatively cache the failure
         return None
 
 
@@ -87,7 +98,7 @@ def get_index() -> indexer.IndexSearch | None:
     return _INDEX
 
 
-def get_url_cache() -> Dict[str, doc_fetcher.Page | None]:
+def get_url_cache() -> Dict[str, Any]:
     """Get the URL cache dictionary.
 
     Returns:

--- a/strands-mcp/tests/test_server.py
+++ b/strands-mcp/tests/test_server.py
@@ -4,8 +4,16 @@ from unittest.mock import patch
 
 import pytest
 
-from strands_mcp_server.server import fetch_doc
+from strands_mcp_server.server import fetch_doc, search_docs
 from strands_mcp_server.utils.doc_fetcher import Page
+
+
+class FailedSentinel:
+    """Minimal sentinel simulating a negatively cached failed fetch entry.
+    
+    Has no .content attribute — same shape as cache._FailedEntry.
+    """
+    pass
 
 
 @patch("strands_mcp_server.server.cache")
@@ -152,3 +160,47 @@ class TestFetchDocErrors:
         tru_result = fetch_doc(uri="https://strandsagents.com/missing.md")
 
         assert tru_result["error"] == "fetch failed"
+
+
+@patch("strands_mcp_server.server.cache")
+class TestSearchDocsWithNegativeCache:
+    """Tests for search_docs resilience with negatively cached failed entries."""
+
+    def test_failed_cache_entry_does_not_crash_hydration_loop(self, mock_cache):
+        """search_docs must not crash when url_cache contains a failed sentinel."""
+        mock_cache.ensure_ready.return_value = None
+        mock_cache.SNIPPET_HYDRATE_MAX = 5
+
+        # Set up a mock index that returns results for a failed URL
+        mock_index = mock_cache.get_index.return_value
+        mock_doc = mock_index.search.return_value = [
+            (0.9, type("Doc", (), {"uri": "https://strandsagents.com/failed.md", "display_title": "Failed Doc"})())
+        ]
+
+        # url_cache contains a FailedSentinel for that URL
+        mock_cache.get_url_cache.return_value = {
+            "https://strandsagents.com/failed.md": FailedSentinel(),
+        }
+
+        # Must not raise AttributeError
+        result = search_docs("test query")
+        assert isinstance(result, list)
+
+    def test_failed_entry_returns_title_as_snippet(self, mock_cache):
+        """When a search result's page has a failed entry, the snippet should
+        fall back to the display title rather than crashing."""
+        mock_cache.ensure_ready.return_value = None
+        mock_cache.SNIPPET_HYDRATE_MAX = 5
+
+        mock_index = mock_cache.get_index.return_value
+        mock_doc = mock_index.search.return_value = [
+            (0.9, type("Doc", (), {"uri": "https://strandsagents.com/failed.md", "display_title": "Failed Doc"})())
+        ]
+
+        mock_cache.get_url_cache.return_value = {
+            "https://strandsagents.com/failed.md": FailedSentinel(),
+        }
+
+        result = search_docs("test query")
+        assert len(result) == 1
+        assert result[0]["snippet"] == "Failed Doc"

--- a/strands-mcp/tests/test_server.py
+++ b/strands-mcp/tests/test_server.py
@@ -71,7 +71,7 @@ class TestFetchDocTocMode:
         assert "preamble" in tru_result
         assert "Experimental hook events" in tru_result["preamble"]
 
-    def test_no_h2_headers_returns_full_content(self, mock_cache, no_h2_doc):
+    def test_no_h2_headers_returns_bounded_content(self, mock_cache, no_h2_doc):
         mock_cache.ensure_page.return_value = Page(
             url="https://strandsagents.com/no-h2.md",
             title="No H2 Doc",
@@ -80,10 +80,12 @@ class TestFetchDocTocMode:
 
         tru_result = fetch_doc(uri="https://strandsagents.com/no-h2.md")
 
-        # No ## sections means fallback to full content
+        # No ## sections means fallback to bounded content — capped at threshold
         assert tru_result["document_small"] is True
         assert tru_result["reason"] == "no_sections"
         assert "content" in tru_result
+        # Verify content is bounded by SMALL_DOC_THRESHOLD
+        assert len(tru_result["content"].encode("utf-8")) <= 8192, "no_sections content must be bounded"
         assert "sections" not in tru_result
 
     @pytest.mark.parametrize("kwargs", [{}, {"uri": ""}], ids=["no-args", "empty-uri"])


### PR DESCRIPTION
Two fixes for strands-mcp fetch/cache/hydration path.

**Negative caching for failed fetches (#3328):**
- _FAILED sentinel distinguishes not-fetched from failed
- Short-circuit known failures instead of re-fetching
- Log exceptions via logger.exception()

**Cap no_sections fallback content (#3327):**
- Truncate structureless documents at SMALL_DOC_THRESHOLD (8KB)
- Append truncation notice
- Updated test to verify bounded content

All 47 existing tests pass.