### PR TITLE
chore: restore root README with archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
 <div align="center">
+
+### :warning: This repository has been archived
+
+**The Strands Agents MCP server has moved to the [strands-agents/harness-sdk](https://github.com/strands-agents/harness-sdk) monorepo.**
+
+The source code is now under [`strands-mcp/`](https://github.com/strands-agents/harness-sdk/tree/main/strands-mcp). All new development, issues, and pull requests should go there.
+
+</div>
+
+---
+
+<div align="center">
   <div>
     <a href="https://strandsagents.com">
       <img src="https://strandsagents.com/latest/assets/logo-github.svg" alt="Strands Agents" width="55px" height="105px">


### PR DESCRIPTION
## Description

This repo has two README problems: the root has no README (the convergence restructuring in #38 moved it into `strands-mcp/`), and nothing signals that the project has moved to the monorepo.

Moves `strands-mcp/README.md` back to the repo root and prepends the same archive banner the other merged repos use ([sdk-typescript](https://github.com/strands-agents/sdk-typescript), [docs](https://github.com/strands-agents/docs)), pointing to the MCP server's new home at [`strands-mcp/`](https://github.com/strands-agents/harness-sdk/tree/main/strands-mcp).
